### PR TITLE
Update to Testify assert package

### DIFF
--- a/randutil_test.go
+++ b/randutil_test.go
@@ -5,7 +5,7 @@ package randutil
 
 import (
 	"fmt"
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	"log"
 	"math"
 	"math/rand"
@@ -134,7 +134,7 @@ func TestWeightedChoice(t *testing.T) {
 	for i, c := range choices[0 : len(choices)-1] {
 		next := choices[i+1]
 		expr := chosenCount[c] < chosenCount[next]
-		assert.T(t, expr)
+		assert.True(t, expr)
 	}
 }
 


### PR DESCRIPTION
From jmcvetta/napping#32, I'm updating across dependent packages to a newer assert package from Testify. It should solve a build error that will provide compatibility with Nut's vendoring system.
