### PR TITLE
Make IntRange explicitly inclusive to [min, max].

### DIFF
--- a/randutil.go
+++ b/randutil.go
@@ -21,23 +21,19 @@ const (
 
 var MinMaxError = errors.New("Min cannot be greater than max.")
 
-// IntRange returns a random integer in the range from min to max.
+// IntRange returns a random integer in the range from min to max inclusive.
 func IntRange(min, max int) (int, error) {
 	var result int
-	switch {
-	case min > max:
+	if min > max {
 		// Fail with error
 		return result, MinMaxError
-	case max == min:
-		result = max
-	case max > min:
-		maxRand := max - min
-		b, err := rand.Int(rand.Reader, big.NewInt(int64(maxRand)))
-		if err != nil {
-			return result, err
-		}
-		result = min + int(b.Int64())
 	}
+	maxRand := max - min + 1
+	b, err := rand.Int(rand.Reader, big.NewInt(int64(maxRand)))
+	if err != nil {
+		return result, err
+	}
+	result = min + int(b.Int64())
 	return result, nil
 }
 
@@ -92,7 +88,7 @@ func AlphaString(n int) (string, error) {
 func ChoiceString(choices []string) (string, error) {
 	var winner string
 	length := len(choices)
-	i, err := IntRange(0, length)
+	i, err := IntRange(0, length - 1)
 	winner = choices[i]
 	return winner, err
 }
@@ -101,7 +97,7 @@ func ChoiceString(choices []string) (string, error) {
 func ChoiceInt(choices []int) (int, error) {
 	var winner int
 	length := len(choices)
-	i, err := IntRange(0, length)
+	i, err := IntRange(0, length - 1)
 	winner = choices[i]
 	return winner, err
 }
@@ -126,7 +122,7 @@ func WeightedChoice(choices []Choice) (Choice, error) {
 	for _, c := range choices {
 		sum += c.Weight
 	}
-	r, err := IntRange(0, sum)
+	r, err := IntRange(0, sum - 1)
 	if err != nil {
 		return ret, err
 	}


### PR DESCRIPTION
It's not entirely clear, but it looks like `IntRange` was meant to be fully inclusive to the range `[min, max]`. Before this change, it was exclusive to `max`, i.e. the range was `[min, max)`.

This change makes `IntRange` fully inclusive. This also fixes a bug in `StringRange` that was only generating strings up to `max - 1` length (instead of generating strings up to `max` length as per its comment).

With this fix, the `max == min` case is handled automatically, so no `switch` is required. I also had to adjust the other utility functions to take into account the inclusive `max`.

If `IntRange` was meant to be `[min, max)` only, feel free to reject this PR, but I'd then recommend fixing `StringRange` and making it clear that `IntRange` excludes `max`.
